### PR TITLE
cross-compatibility with newer asyncio, PIL and cozmoclad

### DIFF
--- a/src/cozmo/annotate.py
+++ b/src/cozmo/annotate.py
@@ -112,6 +112,12 @@ class ImageText:
         self.outline_color = outline_color
         self.full_outline = full_outline
 
+    def textsize(self, draw):
+        if hasattr(draw,'textsize'):
+            return draw.textsize(self.text, self.font)
+        _, _, width, height = draw.textbbox((0,0), text=self.text, font=self.font)
+        return width, height
+
     def render(self, draw, bounds):
         '''Renders the text onto an image within the specified bounding box.
 
@@ -124,7 +130,7 @@ class ImageText:
             The same :class:`PIL.ImageDraw.ImageDraw` object as was passed-in with text applied.
         '''
         (bx1, by1, bx2, by2) = bounds
-        text_width, text_height = draw.textsize(self.text, font=self.font)
+        text_width, text_height = self.textsize(draw)
 
         if self.position & TOP:
             y = by1
@@ -178,7 +184,8 @@ def add_img_box_to_image(image, box, color, text=None):
     x2, y2 = box.right_x, box.bottom_y
     d.rectangle([x1, y1, x2, y2], outline=color)
     if text is not None:
-        if isinstance(text, collections.Iterable):
+        if ((hasattr(collections,'Iterable') and isinstance(text, collections.Iterable)) or 
+                isinstance(text, collections.abc.Iterable)):
             for t in text:
                 t.render(d, (x1, y1, x2, y2))
         else:

--- a/src/cozmo/event.py
+++ b/src/cozmo/event.py
@@ -485,7 +485,10 @@ class Dispatcher(base.Base):
 
         self.add_event_handler(event, f)
         if timeout:
-             return await asyncio.wait_for(f, timeout, loop=self._loop)
+            try:
+                return await asyncio.wait_for(f, timeout, loop=self._loop)
+            except TypeError:
+                return await asyncio.wait_for(f, timeout)
         return await f
 
 

--- a/src/cozmo/run.py
+++ b/src/cozmo/run.py
@@ -361,7 +361,10 @@ class FirstAvailableConnector(DeviceConnector):
 
     async def _do_connect(self, connector,loop, protocol_factory, conn_check):
         connect = connector.connect(loop, protocol_factory, conn_check)
-        result = await asyncio.gather(connect, loop=loop, return_exceptions=True)
+        try:
+            result = await asyncio.gather(connect, loop=loop, return_exceptions=True)
+        except TypeError:
+            result = await asyncio.gather(connect, return_exceptions=True)
         return result[0]
 
     async def connect(self, loop, protocol_factory, conn_check):

--- a/src/cozmo/usbmux/usbmux.py
+++ b/src/cozmo/usbmux/usbmux.py
@@ -449,7 +449,10 @@ class QueueNotifyCM:
         except IndexError:
             pass
         self._wake = asyncio.Future(loop=self.loop)
-        await asyncio.wait_for(self._wake, loop=self.loop, timeout=timeout)
+        try:
+            await asyncio.wait_for(self._wake, loop=self.loop, timeout=timeout)
+        except TypeError:
+            await asyncio.wait_for(self._wake, timeout=timeout)
         return self._q.popleft()
 
 


### PR DESCRIPTION
In newer versions of asyncio, the loop argument for gather() and wait_for() has been removed. In newer versions of PIL, the textsize() method has been removed. The code has been made compatible with both the old and the new versions. Moreover, the reserved keyword in the cozmoclad's error message routine doesn't work with all versions of the cozmoclad library and was removed in the one call that used it.